### PR TITLE
fix: Deploy-Chain + Flatpak-Kompat (closes #84)

### DIFF
--- a/anvil/core/ba2_packer.py
+++ b/anvil/core/ba2_packer.py
@@ -24,7 +24,7 @@ from configparser import ConfigParser
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from anvil.core.subprocess_env import clean_env
+from anvil.core.subprocess_env import clean_env, host_popen
 
 from PySide6.QtCore import QSettings
 
@@ -179,13 +179,20 @@ class BA2Packer:
         Falls back to manual ``Z:`` mapping if winepath fails.
         """
         try:
-            result = subprocess.run(
+            proc = host_popen(
                 ["winepath", "-w", str(linux_path)],
-                capture_output=True, text=True, timeout=5, env=env,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env,
             )
-            if result.returncode == 0 and result.stdout.strip():
-                return result.stdout.strip()
-        except (subprocess.TimeoutExpired, OSError):
+            try:
+                stdout_b, _ = proc.communicate(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                stdout_b, _ = proc.communicate()
+                stdout_b = None
+            result_stdout = stdout_b.decode("utf-8", errors="replace") if stdout_b else ""
+            if proc.returncode == 0 and result_stdout.strip():
+                return result_stdout.strip()
+        except OSError:
             pass
 
         # Fallback: Z: maps the entire Linux root /
@@ -278,20 +285,25 @@ class BA2Packer:
         print(f"[BA2] Running: {' '.join(cmd)}", flush=True)
 
         try:
-            proc = subprocess.run(
+            proc = host_popen(
                 cmd,
                 env=env,
-                capture_output=True,
-                text=True,
-                timeout=300,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
             )
+            try:
+                stdout_b, stderr_b = proc.communicate(timeout=300)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.communicate()
+                return False, f"BSArch timed out after 300s for {output_ba2.name}"
+            proc_stdout = stdout_b.decode("utf-8", errors="replace") if stdout_b else ""
+            proc_stderr = stderr_b.decode("utf-8", errors="replace") if stderr_b else ""
             if proc.returncode != 0:
-                stderr = proc.stderr.strip() or proc.stdout.strip()
+                stderr = proc_stderr.strip() or proc_stdout.strip()
                 return False, f"BSArch exited with code {proc.returncode}: {stderr}"
             print(f"[BA2] Created: {output_ba2.name}", flush=True)
             return True, ""
-        except subprocess.TimeoutExpired:
-            return False, f"BSArch timed out after 300s for {output_ba2.name}"
         except OSError as exc:
             return False, f"Failed to run BSArch: {exc}"
 

--- a/anvil/mainwindow.py
+++ b/anvil/mainwindow.py
@@ -36,7 +36,7 @@ from PySide6.QtWidgets import (
 from PySide6.QtCore import Qt, QModelIndex, QSettings, QTimer, QUrl, QSize
 from PySide6.QtGui import QAction, QActionGroup, QDesktopServices, QIcon, QKeySequence
 
-from anvil.core.subprocess_env import clean_subprocess_env
+from anvil.core.subprocess_env import clean_subprocess_env, host_popen
 from anvil.core.ui_helpers import _center_on_parent, get_text_input
 from anvil.styles.dark_theme import load_theme, default_theme
 from anvil.widgets.toolbar import create_toolbar
@@ -1868,7 +1868,7 @@ class MainWindow(QMainWindow):
             self._game_panel.silent_deploy()
         success, pid = True, -1
         try:
-            proc = subprocess.Popen(
+            proc = host_popen(
                 [binary_path],
                 cwd=working_dir,
                 env=clean_subprocess_env(),
@@ -1906,6 +1906,7 @@ class MainWindow(QMainWindow):
         """Re-enable the UI after a game has stopped or user clicks Unlock."""
         self._game_running = False
         self._game_panel.silent_purge()
+        self._game_panel.silent_deploy()
         self._lock_overlay.setVisible(False)
         self._splitter.setEnabled(True)
         self._log_container.setEnabled(True)
@@ -2362,8 +2363,8 @@ class MainWindow(QMainWindow):
                         if meta_path.is_file():
                             try:
                                 cp.read(str(meta_path), encoding="utf-8")
-                            except Exception:
-                                pass
+                            except Exception as exc:
+                                print(f"[META] parse failed: {meta_path}: {exc}", flush=True)
                         if not cp.has_section("General"):
                             cp.add_section("General")
                         cp.set("General", "removed", "true")
@@ -2446,8 +2447,8 @@ class MainWindow(QMainWindow):
         if meta_path.is_file():
             try:
                 cp.read(str(meta_path), encoding="utf-8")
-            except Exception:
-                pass
+            except Exception as exc:
+                print(f"[META] parse failed: {meta_path}: {exc}", flush=True)
         if not cp.has_section("General"):
             cp.add_section("General")
         cp.set("General", "installed", "true")
@@ -2493,7 +2494,8 @@ class MainWindow(QMainWindow):
             cp.optionxform = str  # CamelCase-Keys beibehalten
             try:
                 cp.read(str(meta_file), encoding="utf-8")
-            except Exception:
+            except Exception as exc:
+                print(f"[META] parse failed: {meta_file}: {exc}", flush=True)
                 continue
             if cp.get("General", "installationFile", fallback="") == old_name:
                 cp.set("General", "installationFile", new_name)
@@ -5074,8 +5076,8 @@ class MainWindow(QMainWindow):
         if meta_path.is_file():
             try:
                 cp.read(str(meta_path), encoding="utf-8")
-            except Exception:
-                pass
+            except Exception as exc:
+                print(f"[META] parse failed: {meta_path}: {exc}", flush=True)
         if not cp.has_section("General"):
             cp.add_section("General")
         cp.set("General", "modID", str(nexus_data.get("mod_id", 0)))

--- a/anvil/widgets/game_panel.py
+++ b/anvil/widgets/game_panel.py
@@ -1100,6 +1100,8 @@ class GamePanel(QWidget):
         needs_redmod = self._needs_redmod_deploy(plugin)
         print(f"[START] _needs_redmod_deploy={needs_redmod}, binary={binary}", flush=True)
         if needs_redmod:
+            # Sicherstellen dass /mods/ gefuellt ist bevor redMod.exe darueber laeuft
+            self.silent_deploy()
             self._run_redmod_deploy_then_launch(plugin, binary, is_steam)
             return
 
@@ -1808,7 +1810,7 @@ class GamePanel(QWidget):
             cmd = [str(proton_script), "run", str(exe)]
             if args:
                 cmd.extend(args)
-            proc = subprocess.Popen(
+            proc = host_popen(
                 cmd, cwd=cwd, env=env,
                 stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
             )
@@ -2013,8 +2015,8 @@ class GamePanel(QWidget):
                             is_hidden = cp.getboolean("General", "removed", fallback=False)
                             meta_installed = cp.getboolean("General", "installed", fallback=False)
                             meta_install_file = cp.get("General", "installationFile", fallback="")
-                        except Exception:
-                            pass
+                        except Exception as exc:
+                            print(f"[META] parse failed: {meta}: {exc}", flush=True)
                     results.append((entry.name, stat.st_size, stat.st_mtime, entry, is_hidden, meta_installed, meta_install_file))
                 except OSError:
                     continue
@@ -2050,8 +2052,8 @@ class GamePanel(QWidget):
                             is_hidden = cp.getboolean("General", "removed", fallback=False)
                             meta_installed = cp.getboolean("General", "installed", fallback=False)
                             meta_install_file = cp.get("General", "installationFile", fallback="")
-                        except Exception:
-                            pass
+                        except Exception as exc:
+                            print(f"[META] parse failed: {meta}: {exc}", flush=True)
                     root_archives.append((entry.name, stat.st_size, stat.st_mtime, entry, is_hidden, meta_installed, meta_install_file))
                 except OSError:
                     continue
@@ -2085,8 +2087,8 @@ class GamePanel(QWidget):
                             dn = cp.get("installed", "name", fallback="")
                             if dn.strip():
                                 installed_names.add(dn.strip().lower())
-                        except Exception:
-                            pass
+                        except Exception as exc:
+                            print(f"[META] parse failed: {meta_ini}: {exc}", flush=True)
 
         s = QSettings(
             str(Path.home() / ".config" / "AnvilOrganizer" / "AnvilOrganizer.conf"),
@@ -2417,7 +2419,8 @@ class GamePanel(QWidget):
         try:
             cp.read(str(meta), encoding="utf-8")
             return cp.getboolean("General", "removed", fallback=False)
-        except Exception:
+        except Exception as exc:
+            print(f"[META] parse failed: {meta}: {exc}", flush=True)
             return False
 
     def _set_hidden(self, row: int, hidden: bool) -> None:
@@ -2431,8 +2434,8 @@ class GamePanel(QWidget):
         if meta_path.is_file():
             try:
                 cp.read(str(meta_path), encoding="utf-8")
-            except Exception:
-                pass
+            except Exception as exc:
+                print(f"[META] parse failed: {meta_path}: {exc}", flush=True)
         if not cp.has_section("General"):
             cp.add_section("General")
         cp.set("General", "removed", str(hidden).lower())

--- a/anvil/widgets/script_merger_dialog.py
+++ b/anvil/widgets/script_merger_dialog.py
@@ -25,6 +25,7 @@ from PySide6.QtCore import Qt, QThread, Signal, QProcess, QSettings
 from PySide6.QtGui import QColor, QFont, QIcon, QPainter, QPixmap
 
 from anvil.core.translator import tr
+from anvil.core.subprocess_env import is_flatpak
 from anvil.core.script_merger.models import (
     MergeStatus,
     MergeInventoryEntry,
@@ -823,7 +824,14 @@ class ScriptMergerDialog(QDialog):
 
         args = files + ["-o", str(output_path)]
         effective_path = resolved or kdiff3_path
-        self._kdiff3_process.start(effective_path, args)
+        if is_flatpak():
+            # Flatpak: KDiff3 ueber flatpak-spawn --host starten,
+            # damit auf Host-Dateisystem zugegriffen werden kann
+            self._kdiff3_process.start(
+                "flatpak-spawn", ["--host", effective_path, *args]
+            )
+        else:
+            self._kdiff3_process.start(effective_path, args)
 
     def _on_kdiff3_finished(self, exit_code: int, exit_status) -> None:
         """Callback wenn KDiff3 beendet wird."""


### PR DESCRIPTION
## Zusammenfassung
7 Fixes aus der systematischen QA-Pruefung am 2026-04-23, zusammen committet weil sie alle zum gleichen Cascade-Bug gehoeren: Cyberpunk crashte beim zweiten aufeinanderfolgenden Start in der selben Anvil-Session mit EXCEPTION_ACCESS_VIOLATION.

## Root-Cause
`_unlock_ui` purged nach Game-Ende `/mods/` ab, aber Anvil deployte vor dem zweiten Game-Start nicht neu. `redMod.exe` lief dann auf leerem Verzeichnis, schrieb eine 15-Byte `mods.json`, Cyberpunks `final.redscripts.modded` verwies auf tote Mod-Referenzen → Null-Pointer beim Script-Resolver → Crash nach 3,5 s.

## Enthaltene Fixes (alle kleine Zeilenaenderungen)
### Deploy-Chain
- `game_panel._on_start_clicked`: `silent_deploy()` vor REDmod-Deploy
- `mainwindow._unlock_ui`: `silent_deploy()` nach `silent_purge()`
- 9 stille `except Exception: pass` in .meta-Parsern loggen jetzt

### Flatpak-Sweep (Nachzug zum 9.-April-Umbau)
- `mainwindow:1871` (Direct-Launch), `game_panel.run_with_proton`, `ba2_packer` (winepath + BSArch), `script_merger_dialog` (KDiff3): alle vier auf `host_popen` / `flatpak-spawn --host`
- `ba2_packer`: zusaetzlich `proc.kill()` im `TimeoutExpired`-Zweig, weil `Popen.communicate(timeout)` im Gegensatz zu `subprocess.run` den Prozess NICHT automatisch killt

## QA-Ergebnis
Workflow mit 4 parallelen Review-Agents gelaufen, 2 Iterationen bis `ACCEPTED × 4 + BUG_GONE` (Iteration 2 nur Timeout-Kill in `ba2_packer`). Reports: `docs/workflow/qa-agent-1.md` bis `-4.md`, `final-verify-2.md`.

## Test
- `./restart.sh` startet sauber
- `python -m py_compile` der 4 Dateien OK
- `grep`-Check: `silent_purge` → `silent_deploy` vor Game-Start beweisbar in beiden Pfaden

## Nicht im Scope
i18n-Keys, Dead Code, `mainwindow.py`-Refactoring — eigene Issues.