### PR TITLE
fix cyberpunk spawn0 wrongly listed as framework

### DIFF
--- a/anvil/plugins/games/game_cyberpunk2077.py
+++ b/anvil/plugins/games/game_cyberpunk2077.py
@@ -71,7 +71,6 @@ class Cyberpunk2077Game(BaseGame):
         "redscript",
         "Native Settings UI",
         "mod_settings",
-        "SPAWN0 - Male and female body correction",
     ]
 
     GameDocumentsDirectory = ""  # resolved dynamically via gameDocumentsDirectory()


### PR DESCRIPTION
SPAWN0 is a plain archive mod - a single `.archive` under `archive/pc/mod/` - but it was listed in `GameDirectInstallMods` alongside eleven real frameworks.

Consequences of the misclassification:

| Effect | Source |
|---|---|
| Hidden from the mod list, so its load order cannot be changed | `mainwindow.py:1932` filters `is_direct_install` |
| Deployed as a copy instead of a symlink | manifest says `"type": "copy"` |
| Allowed to overwrite real game files | `mod_deployer.py:457` |
| Subject to reverse-sync | `mod_deployer.py:517` |

Removing the entry makes it a normal, reorderable mod. It was the only non-framework entry in the list; the other eleven are untouched.

**Note when rolling this out:** a real copy may still sit at the target path. Anvil would then skip the symlink because of the "never overwrite a real game file" guard (`mod_deployer.py:456`), leaving the old copy in place unmanaged. Remove the existing file first, then deploy.

Full test suite: 218 passed, 1 skipped.